### PR TITLE
fix: build FormData properly when sending an array of objects

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -213,6 +213,34 @@ describe('adapter', () => {
         })
       })
     })
+
+    describe('when an array of objects and file is sent is sent', () => {
+      const values = { id: 1, objectArray: [{ foo: 'bar' }, { foo: 'baz' }] }
+
+      beforeEach(() => {
+        data = { objectArray: [{ foo: 'bar' }, { foo: 'baz' }], files: [new File([''], 'filename')] }
+        mock.onPost('/api/users').reply(200, values)
+        action()
+      })
+
+      it('sends a xhr request with data parameters', () => {
+        expect(ret.abort).toBeTruthy()
+
+        return ret.promise.then((vals) => {
+          expect(vals).toEqual(values)
+
+          const { params, data, headers, withCredentials } = getLastRequest('post')
+          expect(headers).toEqual({
+            'Accept': 'application/json, text/plain, */*',
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'SomeHeader': 'test'
+          })
+          expect(params).toEqual(undefined)
+          expect(Array.from(data.keys())).toEqual(['objectArray[0][foo]', 'objectArray[1][foo]', 'files[]'])
+          expect(withCredentials).toEqual(true)
+        })
+      })
+    })
   })
 
   describe('put', () => {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
     "url": "git@github.com:factorialco/mobx-rest-axios-adapter.git"
   },
   "license": "MIT",
-  "jest": { "preset": "ts-jest" },
+  "jest": {
+    "preset": "ts-jest"
+  },
   "dependencies": {
     "axios": "0.19.0",
+    "lodash": "^4.17.15",
     "qs": "6.9.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   },
   "dependencies": {
     "axios": "0.19.0",
-    "lodash": "^4.17.15",
     "qs": "6.9.0"
   },
   "devDependencies": {

--- a/src/buildFormData.ts
+++ b/src/buildFormData.ts
@@ -1,5 +1,3 @@
-import { isPlainObject } from 'lodash'
-
 function isFile(val) {
   return val instanceof File
 }
@@ -7,6 +5,10 @@ function isFile(val) {
 type Payload = {
   hasFile: boolean,
   formData: FormData | null
+}
+
+const isPlainObject = (obj: any) => {
+  return typeof obj === 'object' && obj.constructor === Object
 }
 
 export default function buildFormData (data: { [key: string]: any } | null): Payload {

--- a/src/buildFormData.ts
+++ b/src/buildFormData.ts
@@ -1,3 +1,5 @@
+import { isPlainObject } from 'lodash'
+
 function isFile(val) {
   return val instanceof File
 }
@@ -24,7 +26,15 @@ export default function buildFormData (data: { [key: string]: any } | null): Pay
     const val = data[attr]
 
     if (Array.isArray(val)) {
-      val.forEach(nestedVal => appendFile(`${attr}[]`, nestedVal))
+      val.forEach(function (nestedVal, index) {
+        if (isPlainObject(nestedVal)) {
+          for (const prop in nestedVal) {
+            appendFile(`${attr}[${index}][${prop}]`, nestedVal[prop])
+          }
+        } else {
+          appendFile(attr + "[]", nestedVal);
+        }
+      });
     } else {
       appendFile(attr, val)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2399,7 +2399,7 @@ lodash.unescape@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
 
@@ -2979,6 +2979,11 @@ punycode@^1.4.1:
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+
+qs@6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.0.tgz#d1297e2a049c53119cb49cca366adbbacc80b409"
+  integrity sha512-27RP4UotQORTpmNQDX8BHPukOnBP3p1uUJY5UnDhaJB+rMt9iMsok724XL+UHU23bEFOHRMQ2ZhI99qOWUMGFA==
 
 qs@~6.5.2:
   version "6.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2399,7 +2399,7 @@ lodash.unescape@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
 


### PR DESCRIPTION
There was a problem when creating hte formData to send to the server
when the data given was an array of objects. Instead of creating a
structure like

objectArray[index][propObj] = value

the library was creating the structure

objectArray[] = "[object object]"