### PR TITLE
Check for file attributes to build form-data request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.6
+
+Consider params with keys `uri`, `name` and `type` as Files to build FormData requests.
+
 ## 0.1.5
 
 Build FormData properly when sending an array of objects

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -186,6 +186,40 @@ describe('adapter', () => {
       })
     })
 
+    describe('when it contains an attribute with name, uri and type', () => {
+      const values = { id: 1, avatar: 'lol.png' }
+
+      beforeEach(() => {
+        data = {
+          avatar: {
+            uri: 'some://uri/lol.png',
+            name: 'filename',
+            type: 'image/png'
+          }
+        }
+        mock.onPost('/api/users').reply(200, values)
+        action()
+      })
+
+      it('sends a xhr request with data parameters', () => {
+        expect(ret.abort).toBeTruthy()
+
+        return ret.promise.then((vals) => {
+          expect(vals).toEqual(values)
+
+          const { params, data, headers, withCredentials } = getLastRequest('post')
+          expect(headers).toEqual({
+            'Accept': 'application/json, text/plain, */*',
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'SomeHeader': 'test'
+          })
+          expect(params).toEqual(undefined)
+          expect(Array.from(data.keys())).toEqual(['avatar'])
+          expect(withCredentials).toEqual(true)
+        })
+      })
+    })
+
     describe('when it contains an array of files', () => {
       const values = [{ id: 1, avatar: 'lol.png' }]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factorial-mobx-rest-axios-adapter",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "official axios adapter for mobx-rest",
   "repository": {
     "type": "git",

--- a/src/buildFormData.ts
+++ b/src/buildFormData.ts
@@ -1,5 +1,10 @@
 function isFile(val) {
-  return val instanceof File
+  if (val instanceof File) return true
+
+  const fileKeys = ['uri', 'name', 'type']
+  if (fileKeys.every(_key => val.hasOwnProperty(_key))) return true
+
+  return false
 }
 
 type Payload = {


### PR DESCRIPTION
Right when developing our mobile `react-native` app I stepped upon an interesting blocker within this package and mobile files management.

Our frontend uses the native `File` interface, which comes for free when dealing with any kind of files there, and so this adapter checks that interface in order to perform a `form-data` request or a regular `json` request. This works like a charm: our frontend doesn't have any extra work and with this library we take care of the request form. Awesome!

Mobile world is special. Natively `File` is practically inexistent and instantiating requires some black magic between blobs and file readers which, sadly, I didn't manage to achieve successfully.
As stated in various places [here](https://medium.com/@istvanistvan/react-native-file-uploads-with-axios-and-redux-thunk-73d8093d7243) and [there](https://gist.github.com/nandorojo/c641c176a053a9ab43462c6da1553a1b), given a file uri is super easy to upload files to a server, using plain information and a simple `form-data` request. This interceptor is not allowing us that though, since requires a `File` instance to perform the request this way.

That's why I'm adding a new check to consider an attribute as a file, which is super simple actually: check if the given value has `uri`, `name` and `type` keys. If it does we consider it's a file, and the adapter builds the request `form-data` like.