### PR TITLE
Prepare the adapter for mobx-rest 10

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -22,8 +22,7 @@ describe('adapter', () => {
       beforeEach(() => { mock.onGet('/api/users').reply(500, 'ERROR') })
 
       it('returns an empty error', () => {
-        const { abort, promise } = adapter.get('/users', {})
-        expect(abort).toBeTruthy()
+        const promise = adapter.get('/users', {})
 
         return expect(promise).rejects.toEqual(new Error('Request failed with status code 500'))
       })
@@ -31,10 +30,10 @@ describe('adapter', () => {
   })
 
   describe('get', () => {
-    let ret
+    let promise
 
     const action = () => {
-      ret = adapter.get('/users', { manager_id: [2] })
+      promise = adapter.get('/users', { manager_id: [2] })
     }
 
     describe('when it resolves', () => {
@@ -46,9 +45,7 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return ret.promise.then((vals) => {
+        return promise.then((vals) => {
           expect(vals).toEqual(values)
 
           const { params, data, headers, withCredentials } = getLastRequest('get')
@@ -71,19 +68,17 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return expect(ret.promise).rejects.toEqual(['foo'])
+        return expect(promise).rejects.toEqual(['foo'])
       })
     })
   })
 
   describe('post', () => {
-    let ret
+    let promise
     let data
 
     const action = () => {
-      ret = adapter.post('/users', data)
+      promise = adapter.post('/users', data)
     }
 
     describe('when it resolves', () => {
@@ -96,9 +91,7 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return ret.promise.then((vals) => {
+        return promise.then((vals) => {
           expect(vals).toEqual(values)
 
           const { params, data, headers, withCredentials } = getLastRequest('post')
@@ -124,9 +117,7 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return expect(ret.promise).rejects.toEqual(['foo'])
+        return expect(promise).rejects.toEqual(['foo'])
       })
     })
 
@@ -140,9 +131,7 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return ret.promise.then((vals) => {
+        return promise.then((vals) => {
           expect(vals).toEqual(values)
 
           const { params, data, headers, withCredentials } = getLastRequest('post')
@@ -168,9 +157,7 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return ret.promise.then((vals) => {
+        return promise.then((vals) => {
           expect(vals).toEqual(values)
 
           const { params, data, headers, withCredentials } = getLastRequest('post')
@@ -202,9 +189,7 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return ret.promise.then((vals) => {
+        return promise.then((vals) => {
           expect(vals).toEqual(values)
 
           const { params, data, headers, withCredentials } = getLastRequest('post')
@@ -230,9 +215,7 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return ret.promise.then((vals) => {
+        return promise.then((vals) => {
           expect(vals).toEqual(values)
 
           const { params, data, headers, withCredentials } = getLastRequest('post')
@@ -258,9 +241,7 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return ret.promise.then((vals) => {
+        return promise.then((vals) => {
           expect(vals).toEqual(values)
 
           const { params, data, headers, withCredentials } = getLastRequest('post')
@@ -278,11 +259,11 @@ describe('adapter', () => {
   })
 
   describe('put', () => {
-    let ret
+    let promise
     const data = { name: 'paco' }
 
     const action = () => {
-      ret = adapter.put('/users', data)
+      promise = adapter.put('/users', data)
     }
 
     describe('when it resolves', () => {
@@ -294,9 +275,7 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return ret.promise.then((vals) => {
+        return promise.then((vals) => {
           expect(vals).toEqual(values)
 
           const { params, data, headers, withCredentials } = getLastRequest('put')
@@ -321,19 +300,17 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return expect(ret.promise).rejects.toEqual(['foo'])
+        return expect(promise).rejects.toEqual(['foo'])
       })
     })
   })
 
   describe('patch', () => {
-    let ret
+    let promise
     const data = { name: 'paco' }
 
     const action = () => {
-      ret = adapter.patch('/users', data)
+      promise = adapter.patch('/users', data)
     }
 
     describe('when it resolves', () => {
@@ -345,9 +322,7 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return ret.promise.then((vals) => {
+        return promise.then((vals) => {
           expect(vals).toEqual(values)
 
           const { params, data, headers, withCredentials } = getLastRequest('patch')
@@ -372,18 +347,16 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return expect(ret.promise).rejects.toEqual(['foo'])
+        return expect(promise).rejects.toEqual(['foo'])
       })
     })
   })
 
   describe('del', () => {
-    let ret
+    let promise
 
     const action = () => {
-      ret = adapter.del('/users', { name: 'paco' })
+      promise = adapter.del('/users', { name: 'paco' })
     }
 
     describe('when it resolves', () => {
@@ -395,9 +368,7 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return ret.promise.then((vals) => {
+        return promise.then((vals) => {
           expect(vals).toEqual(values)
 
           const { params, data, headers, withCredentials } = getLastRequest('delete')
@@ -422,9 +393,7 @@ describe('adapter', () => {
       })
 
       it('sends a xhr request with data parameters', () => {
-        expect(ret.abort).toBeTruthy()
-
-        return expect(ret.promise).rejects.toEqual(['foo'])
+        return expect(promise).rejects.toEqual(['foo'])
       })
     })
   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "factorial-mobx-rest-axios-adapter",
-  "version": "0.1.6",
+  "version": "1.0.0",
   "description": "official axios adapter for mobx-rest",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,6 @@ import axios from 'axios'
 import { stringify } from 'qs'
 import buildFormData from './buildFormData'
 
-type Request = {
-  abort: () => void;
-  promise: Promise<any>;
-}
-
 type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
 type Options = {
   method: Method;
@@ -48,7 +43,7 @@ function ajaxOptions (options: Options): {} {
   }
 }
 
-function ajax (url: string, options: Options): Request {
+function ajax (url: string, options: Options): Promise<any> {
   const CancelToken = axios.CancelToken
   const source = CancelToken.source()
 
@@ -58,7 +53,7 @@ function ajax (url: string, options: Options): Request {
     ...ajaxOptions(options)
   })
 
-  const promise = new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     request
       .then(response => resolve(response.data))
       .catch(error => {
@@ -68,17 +63,13 @@ function ajax (url: string, options: Options): Request {
         return reject(json.errors || error)
       })
   })
-
-  const abort = () => source.cancel()
-
-  return { abort, promise }
 }
 
 export default {
   apiPath: '',
   commonOptions: {},
 
-  get (path: string, data: {} | null, options: {} = {}): Request {
+  get (path: string, data: {} | null, options: {} = {}): Promise<any> {
     const baseUrl = `${this.apiPath}${path}`
     const url = Object.entries(data || {}).length
       ? `${baseUrl}?${stringify(data, { arrayFormat: 'brackets' })}`
@@ -91,7 +82,7 @@ export default {
     })
   },
 
-  post (path: string, data: {} | null, options: {} = {}): Request {
+  post (path: string, data: {} | null, options: {} = {}): Promise<any> {
     return ajax(`${this.apiPath}${path}`, {
       method: 'POST',
       data,
@@ -100,7 +91,7 @@ export default {
     })
   },
 
-  put (path: string, data: {} | null, options: {} = {}): Request {
+  put (path: string, data: {} | null, options: {} = {}): Promise<any> {
     return ajax(`${this.apiPath}${path}`, {
       method: 'PUT',
       data,
@@ -109,7 +100,7 @@ export default {
     })
   },
 
-  patch (path: string, data: {} | null, options: {} = {}): Request {
+  patch (path: string, data: {} | null, options: {} = {}): Promise<any> {
     return ajax(`${this.apiPath}${path}`, {
       method: 'PATCH',
       data,
@@ -118,7 +109,7 @@ export default {
     })
   },
 
-  del (path: string, data: {} | null, options: {} = {}): Request {
+  del (path: string, data: {} | null, options: {} = {}): Promise<any> {
     return ajax(`${this.apiPath}${path}`, {
       method: 'DELETE',
       data,


### PR DESCRIPTION
`mobx-rest` api was refactored removing the `Request` wrapper.
This forced to refactor the connected adapter to it.